### PR TITLE
Add reusable workflows: pkgdown, R-CMD-check, test-coverage

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,148 @@
+# Reusable R CMD check workflow for PredictiveEcology R packages.
+#
+# Call it from a package repo (which owns the triggers), e.g.:
+#
+#   name: R-CMD-check
+#   on:
+#     push: { branches: [main, master, development] }
+#     pull_request: { branches: [main, master, development] }
+#   jobs:
+#     R-CMD-check:
+#       uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@v0
+#       secrets: inherit
+#       with:
+#         extra-packages: |
+#           PredictiveEcology/Require@development
+name: R-CMD-check
+
+on:
+  workflow_call:
+    inputs:
+      extra-packages:
+        description: "Packages appended to setup-r-dependencies `extra-packages` (newline-separated)."
+        type: string
+        default: ""
+      post-install:
+        description: "Optional Rscript run after dependency install (e.g. NLMR/fastshp)."
+        type: string
+        default: ""
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   nosuggests: false, r: 'release'}
+          - {os: windows-latest, nosuggests: false, r: 'devel'}
+          - {os: windows-latest, nosuggests: false, r: 'release'}
+          - {os: windows-latest, nosuggests: false, r: 'oldrel-1'}
+          - {os: ubuntu-latest,   nosuggests: false, r: 'devel'}
+          - {os: ubuntu-latest,   nosuggests: false, r: 'release'}
+          - {os: ubuntu-latest,   nosuggests: true,  r: 'release'}
+          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel-1'}
+
+    env:
+      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GOOGLEDRIVE_AUTH: ${{ secrets.ELIOT_GOOGLE_AUTHENTICATION }}
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # setup-pandoc occasionally fails with HTTP 5xx (CDN blip).
+      # Three attempts with continue-on-error ride out transient failures.
+      - id: pandoc1
+        continue-on-error: true
+        uses: r-lib/actions/setup-pandoc@v2
+      - if: steps.pandoc1.outcome == 'failure'
+        id: pandoc2
+        continue-on-error: true
+        uses: r-lib/actions/setup-pandoc@v2
+      - if: steps.pandoc1.outcome == 'failure' && steps.pandoc2.outcome == 'failure'
+        uses: r-lib/actions/setup-pandoc@v2
+
+      # Install geospatial system deps WITHOUT the ubuntugis-unstable PPA.
+      # That PPA installs libgdal37 (GDAL 3.11.x), but Posit's noble binary cache
+      # builds quickPlot/sf/terra against the Ubuntu-default libgdal34 -- the ABI
+      # mismatch surfaces as `libgdal.so.34: cannot open shared object file` when
+      # quickPlot loads (and fails the whole check via SpaDES.core lazy-load).
+      - name: Install geospatial system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
+        shell: bash
+      - name: Install geospatial system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install pkg-config
+          brew install gdal
+        shell: zsh {0}
+
+      # Homebrew's gdal/proj install does not always leave proj.db on PROJ's
+      # default search path. Without it, terra::project()/terra::crs() emit
+      # "PROJ: proj_identify: Cannot find proj.db (GDAL error 1)" and any
+      # reprojection-touching test fails. Point PROJ at Homebrew's data dir.
+      - name: Configure PROJ data path (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          PROJ_PREFIX="$(brew --prefix proj 2>/dev/null || true)"
+          PROJ_DATA="$PROJ_PREFIX/share/proj"
+          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/opt/homebrew/share/proj"; fi
+          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/usr/local/share/proj"; fi
+          echo "PROJ_DATA=$PROJ_DATA" >> "$GITHUB_ENV"
+          echo "PROJ_LIB=$PROJ_DATA"  >> "$GITHUB_ENV"
+          echo "Using PROJ_DATA=$PROJ_DATA"
+          ls -1 "$PROJ_DATA" | head -5 || true
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
+          Ncpus: 2
+          r-version: ${{ matrix.config.r }}
+          # Posit Public Package Manager — pre-built Windows + macOS binaries
+          # served from a CDN. More reliable than CRAN mirrors for binaries.
+          use-public-rspm: true
+
+      - id: deps
+        continue-on-error: true
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # Pin pak to its stable channel; devel occasionally regresses.
+          pak-version: stable
+          extra-packages: |
+            any::rcmdcheck
+            ${{ inputs.extra-packages }}
+
+      # Fallback when setup-r-dependencies fails (most often a transient
+      # binary-fetch failure under pak). Up to 3 attempts with 60s backoff.
+      # `nick-fields/retry@v3` does not accept `shell: Rscript {0}`, so we
+      # invoke Rscript -e from bash.
+      - name: Install R deps (retry fallback)
+        if: steps.deps.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          command: |
+            Rscript -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")' \
+                    -e 'pak::local_install_dev_deps(ask = FALSE, dependencies = TRUE)' \
+                    -e 'pak::pkg_install("any::rcmdcheck", ask = FALSE)'
+
+      - name: Install additional package dependencies
+        if: ${{ inputs.post-install != '' }}
+        run: ${{ inputs.post-install }}
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,7 +53,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # setup-pandoc occasionally fails with HTTP 5xx (CDN blip).
       # Three attempts with continue-on-error ride out transient failures.

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -39,7 +39,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -43,7 +43,16 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      # Stock Noble apt (replicates reproducible). The ubuntugis-unstable PPA
+      # used by install-spatial-deps installs libgdal37, which is ABI-incompatible
+      # with the binaries in Posit's noble cache and breaks geospatial loads.
+      - name: Install spatial deps (Linux, stock Noble)
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -f -y || true
+          sudo apt-get install -y --fix-missing \
+            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
+        shell: bash
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,77 @@
+# Reusable pkgdown workflow for PredictiveEcology R packages.
+#
+# Call it from a package repo (which owns the triggers), e.g.:
+#
+#   name: pkgdown
+#   on:
+#     push: { branches: [main, master] }
+#     pull_request: { branches: [main, master] }
+#     release: { types: [published] }
+#     workflow_dispatch:
+#   jobs:
+#     pkgdown:
+#       uses: PredictiveEcology/actions/.github/workflows/pkgdown.yaml@v0
+#       secrets: inherit
+#       with:
+#         extra-packages: |
+#           PredictiveEcology/Require@development
+#         post-install: |
+#           pak::pkg_install("ropensci/NLMR")
+name: pkgdown
+
+on:
+  workflow_call:
+    inputs:
+      extra-packages:
+        description: "Packages appended to setup-r-dependencies `extra-packages` (newline-separated)."
+        type: string
+        default: ""
+      post-install:
+        description: "Optional Rscript run after dependency install (e.g. NLMR/fastshp)."
+        type: string
+        default: ""
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
+          Ncpus: 2
+          use-public-rspm: false
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::pkgdown
+            local::.
+            ${{ inputs.extra-packages }}
+          needs: website
+
+      - name: Install additional package dependencies
+        if: ${{ inputs.post-install != '' }}
+        run: ${{ inputs.post-install }}
+        shell: Rscript {0}
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -42,7 +42,16 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      # Stock Noble apt (replicates reproducible). The ubuntugis-unstable PPA
+      # used by install-spatial-deps installs libgdal37, which is ABI-incompatible
+      # with the binaries in Posit's noble cache and breaks geospatial loads.
+      - name: Install spatial deps (Linux, stock Noble)
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -f -y || true
+          sudo apt-get install -y --fix-missing \
+            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
+        shell: bash
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,66 @@
+# Reusable test-coverage (covr) workflow for PredictiveEcology R packages.
+#
+# Call it from a package repo (which owns the triggers), e.g.:
+#
+#   name: test-coverage
+#   on:
+#     push: { branches: [main, development] }
+#     pull_request: { branches: [main, development] }
+#   jobs:
+#     test-coverage:
+#       uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@v0
+#       secrets: inherit
+#       with:
+#         extra-packages: |
+#           PredictiveEcology/Require@development
+name: test-coverage
+
+on:
+  workflow_call:
+    inputs:
+      extra-packages:
+        description: "Packages appended to setup-r-dependencies `extra-packages` (newline-separated)."
+        type: string
+        default: ""
+      post-install:
+        description: "Optional Rscript run after dependency install (e.g. NLMR/fastshp)."
+        type: string
+        default: ""
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GOOGLEDRIVE_AUTH: ${{ secrets.GOOGLEDRIVE_AUTH }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      USING_COVR: true
+      NOT_CRAN: "true"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
+          Ncpus: 2
+          use-public-rspm: false
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::covr
+            ${{ inputs.extra-packages }}
+
+      - name: Install additional package dependencies
+        if: ${{ inputs.post-install != '' }}
+        run: ${{ inputs.post-install }}
+        shell: Rscript {0}
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -38,7 +38,7 @@ jobs:
       NOT_CRAN: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Adds three `workflow_call` reusable workflows so the package ecosystem can share one maintained copy of each CI workflow instead of copy-pasting (and drifting) per repo.

- `.github/workflows/pkgdown.yaml`
- `.github/workflows/R-CMD-check.yaml` (keeps the OS/R matrix, pandoc-retry, geospatial/PROJ setup, and pak retry-fallback)
- `.github/workflows/test-coverage.yaml`

Each exposes `extra-packages` and `post-install` inputs and uses `secrets: inherit`. The pkgdown one drops the orphaned `r-version: ${{ matrix.config.r }}` that broke `setup-r` in the standalone copies.

**Being piloted on SpaDES.project only** (its 3 caller stubs reference `@reusable-workflows` for now). Once green, suggest tagging (e.g. move `v0` / cut `v0.4`) and pointing callers at the tag, then rolling the stubs out to the other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)