### PR TITLE
test-coverage: skip unreadable covr trace files instead of aborting merge

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -78,5 +78,39 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        run: covr::codecov(quiet = FALSE)
+        # Wraps covr::merge_coverage.character to skip unreadable per-test trace
+        # files (zero-byte or truncated RDS) instead of aborting with the cryptic
+        # `Error in readRDS(f) : error reading from connection`. Root cause: a
+        # test that spawns a subprocess (e.g. callr::r_bg) sometimes leaves a
+        # child alive that the session can't terminate ("Error while shutting
+        # down parallel: unable to terminate some child processes"); that
+        # orphan's covr trace file is created but never flushed. Skipping it
+        # loses only the orphan's coverage and lets the rest report normally.
+        # The skip is logged with the file path and size so a real corruption
+        # (vs. a benign orphan) is still visible.
+        run: |
+          ns <- asNamespace("covr")
+          orig <- get("merge_coverage.character", envir = ns, inherits = FALSE)
+          wrapped <- function(x, ...) {
+            readable <- vapply(x, function(f) {
+              if (!file.exists(f) || !isTRUE(file.size(f) > 0)) return(FALSE)
+              isTRUE(tryCatch({ readRDS(f); TRUE }, error = function(e) FALSE))
+            }, logical(1))
+            skipped <- x[!readable]
+            if (length(skipped)) {
+              message("test-coverage: skipping ", length(skipped),
+                      " unreadable covr trace file(s) (likely from a child ",
+                      "process that didn't flush; see workflow comment):")
+              for (f in skipped) {
+                sz <- if (file.exists(f)) file.size(f) else NA_integer_
+                message(sprintf("  [%s bytes] %s", format(sz), f))
+              }
+            }
+            orig(x[readable], ...)
+          }
+          unlockBinding("merge_coverage.character", ns)
+          assign("merge_coverage.character", wrapped, envir = ns)
+          lockBinding("merge_coverage.character", ns)
+
+          covr::codecov(quiet = FALSE)
         shell: Rscript {0}


### PR DESCRIPTION
## Summary

Wraps `covr::merge_coverage.character` in the reusable test-coverage workflow to **skip unreadable trace files** (zero-byte or truncated RDS) instead of aborting the merge step with the cryptic `Error in readRDS(f) : error reading from connection`.

## Why

The current behavior breaks coverage uploads on PE packages that spawn subprocesses in their test suite (e.g. SpaDES.project uses \`callr::r_bg\` in \`test-experimentFuture.R\` / \`test-experimentMonitor.R\`). The exact failure pattern observed on SpaDES.project (PR #102 / #103 against \`development\`, and on \`development\` itself):

1. All 330 testthat tests pass cleanly.
2. R session exits with: \`Error while shutting down parallel: unable to terminate some child processes\`
3. The orphan's covr trace file exists in the merge list but is 0 bytes (the child died before flushing its coverage data).
4. \`covr::merge_coverage.character\` does \`readRDS()\` on every file in the list and aborts on the empty one.
5. Test-coverage job fails despite the package itself being healthy.

Diagnostic from a debug workflow on SpaDES.project's \`covr-debug\` branch:

\`\`\`
=== merge_coverage.character: 5 trace file(s) ===
  [    569845 bytes] covr_trace_24645ee701b0    -- OK
  [         0 bytes] covr_trace_24a12e1f3261    -- CORRUPT: error reading from connection
  [    561487 bytes] covr_trace_24d87d95cfcb    -- OK
  [    561486 bytes] covr_trace_24e31451b7d9    -- OK
  [    561105 bytes] covr_trace_71d6543f1134    -- OK
\`\`\`

The orphan-child cleanup is a separate, harder root-cause problem (callr/parallel teardown semantics under coverage instrumentation). This PR is the right layer to fix CI: a child that didn't flush has nothing to contribute to coverage anyway, so skipping its trace file is information-neutral.

## What changes

- \`merge_coverage.character\` is patched in-place in the same R session that runs \`covr::codecov()\`.
- For each trace file: if it doesn't exist, is empty, or fails \`readRDS()\`, it's dropped from the merge input.
- Each skipped file is logged with its path + size so a *real* corruption stays visible (distinct from a benign orphan).
- The original \`merge_coverage.character\` is called with the filtered list.

## Test plan

- [ ] Re-trigger test-coverage on SpaDES.project PRs #102 and #103 once this merges — they should both go green (the underlying empty-trace condition has been reproduced).
- [ ] Confirm that on a coverage run with *no* orphans, the wrapper is a no-op (no \"skipping\" messages, normal coverage report uploaded).
- [ ] Confirm the skip-and-log message is visible in the workflow log when the orphan condition reoccurs.

## Follow-ups (separate)

- Address the underlying child-process leak in SpaDES.project's \`killExperimentFuture()\` (likely needs a \`p\$wait(timeout = N)\` after \`p\$kill()\` and a louder error than \`try(..., silent = TRUE)\` when the kill fails). That's out of scope here — this PR is the workflow-layer safety net so a leak doesn't break coverage reporting for the whole repo ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)